### PR TITLE
feat(base): NULL-168 added possibility to specify IPs to gateways

### DIFF
--- a/charts/base/templates/gateways.yaml
+++ b/charts/base/templates/gateways.yaml
@@ -25,6 +25,10 @@ metadata:
     "helm.sh/resource-policy": "keep"
 spec:
   gatewayClassName: istio
+  {{- with .Values.gateway.internal.addresses }}
+  addresses:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   listeners:
   - name: default
     port: 443
@@ -49,6 +53,10 @@ metadata:
     "helm.sh/resource-policy": "keep"
 spec:
   gatewayClassName: istio
+  {{- with .Values.gateway.public.addresses }}
+  addresses:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   listeners:
   - name: default
     port: 443

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -18,11 +18,13 @@ tls:
 gateway:
   internal:
     name: "gateway-private"
+    addresses: {}
     autoscaling:
       minReplicas: 2
       maxReplicas: 10
   public:
     name: "gateway-public"
+    addresses: {}
     autoscaling:
       minReplicas: 2
       maxReplicas: 10


### PR DESCRIPTION
This is the doc https://gateway-api.sigs.k8s.io/reference/spec/#gatewayspecaddress

BREAKING CHANGE:
no
