### PR TITLE
Add missing conditional wrapper

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.initScripts }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Issue
Hay un `{{- end }}` huerfano en el configmap.yaml.

Falta el `{{- if .Values.initScripts }}` al inicio para que solo cree el ConfigMap cuando realmente hay scripts definidos.

```  Error: parse error at
(nullplatform-agent/templates/configmap.yaml:13): unexpected
{{end}}
```

Al agregarlo usando initScripts habilitado, se crea el configmap correctamente y en caso contrario no falla el helm template.