### PR TITLE
fix(base): configure finalizer to run as non-root user

### DIFF
--- a/charts/base/templates/finalizer.yaml
+++ b/charts/base/templates/finalizer.yaml
@@ -11,9 +11,22 @@ spec:
       name: {{ .Release.Name }}-finalizer
     spec:
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: blocker
           image: alpine:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Add security context to finalizer job to enforce running as UID 1000 with read-only root filesystem and dropped capabilities