### PR TITLE
fix(base): resolve installGatewayV2Crd serviceaccount timing issue

### DIFF
--- a/charts/base/templates/clusterrolebindings.yaml
+++ b/charts/base/templates/clusterrolebindings.yaml
@@ -44,6 +44,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nullplatform-crd-installer-binding
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/base/templates/clusterroles.yaml
+++ b/charts/base/templates/clusterroles.yaml
@@ -34,6 +34,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nullplatform-crd-installer
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/charts/base/templates/serviceaccount.yaml
+++ b/charts/base/templates/serviceaccount.yaml
@@ -10,4 +10,7 @@ kind: ServiceAccount
 metadata:
   name: nullplatform-crd-installer-sa
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
 {{- end }}


### PR DESCRIPTION
Add helm hook annotations to CRD installer RBAC resources to ensure they are created before the pre-install job runs, preventing "serviceaccount not found" errors.