### PR TITLE
chore(ci): use reusable workflows from actions-nullplatform-terraform

### DIFF
--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -7,33 +7,10 @@ on:
 
 jobs:
   branch-name:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Validate branch name
-        run: ./scripts/validate-branch-name.sh "${{ github.head_ref }}"
+    uses: nullplatform/actions-nullplatform-terraform/.github/workflows/branch-validation.yml@main
 
   commitlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "22"
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Validate commit messages
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.sha }} --verbose
+    uses: nullplatform/actions-nullplatform-terraform/.github/workflows/conventional-commit.yml@main
 
   lint-charts:
     runs-on: ubuntu-24.04

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,34 +1,3 @@
 module.exports = {
-    extends: ['@commitlint/config-conventional'],
-    rules: {
-        'subject-case': [0, 'always', ['lower-case']], // Disable case checking for subject
-        'subject-empty': [2, 'never'],
-        'type-empty': [2, 'never'],
-        'subject-full-stop': [2, 'never', '.'],
-        'type-enum': [
-            2,
-            'always',
-            [
-                'feat',
-                'fix',
-                'docs',
-                'style',
-                'refactor',
-                'perf',
-                'test',
-                'build',
-                'ci',
-                'chore',
-                'revert'
-            ]
-        ],
-        'body-max-line-length': [0] // Setting to 0 disables the rule
-    },
-    parserPreset: {
-        parserOpts: {
-            headerPattern: /^(\w*)(?:\(([a-z0-9-]*)\))?: (?:([A-Z]+-[0-9]+) )?(.*)$/,            
-            headerCorrespondence: ['type', 'scope', 'ticket', 'subject']
-        }
-    }
+    extends: ['@commitlint/config-conventional']
 };
-

--- a/scripts/validate-branch-name.sh
+++ b/scripts/validate-branch-name.sh
@@ -6,15 +6,15 @@ if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
   exit 0
 fi
 
-pattern='^(feature|bugfix|hotfix|chore)/[a-z0-9-]+$|^release/[0-9]+\.[0-9]+\.[0-9]+$|^(main|master)$'
+pattern='^(feat|feature|fix|docs|style|refactor|perf|test|build|ci|chore|revert)/.+$|^(main|master)$'
 if echo "$branch" | grep -Eq "$pattern"; then
   exit 0
 fi
 
 cat <<EOF
 Invalid branch name: $branch
-Expected:
-- feature|bugfix|hotfix|chore/<kebab-case>
-- release/x.y.z
+Expected: type/description
+  Examples: feat/add-login, fix/bug-123, docs/readme
+Valid types: feat, feature, fix, docs, style, refactor, perf, test, build, ci, chore, revert
 EOF
 exit 1


### PR DESCRIPTION
## Summary
- Replace local `branch-name` and `commitlint` CI jobs with reusable workflows from `nullplatform/actions-nullplatform-terraform`
- Update branch naming convention to use conventional commit types (`feat`, `feature`, `fix`, `docs`, etc.) instead of `feature/bugfix/hotfix` prefixes
- Simplify `commitlint.config.js` to only extend `@commitlint/config-conventional`

## Changes
| File | Change |
|------|--------|
| `.github/workflows/validate-commits.yml` | Use reusable workflows |
| `commitlint.config.js` | Simplified to minimal config |
| `scripts/validate-branch-name.sh` | Updated pattern to match remote |

## Test plan
- [ ] Verify CI jobs run correctly using the reusable workflows
- [ ] Test local hooks still work with the new branch pattern

🤖 Generated with [Claude Code](https://claude.ai/code)