### PR TITLE
fix(ci): add fetch-depth to update-docs checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.release-please.outputs.pr_branch }}
+          fetch-depth: 0
 
       - name: Install helm-docs
         run: |


### PR DESCRIPTION
## Summary

- Fixes the `update-docs` job in the release workflow which fails with `fatal: bad revision 'origin/main...HEAD'`
- The checkout of the Release Please PR branch needs `fetch-depth: 0` so `origin/main` is available for the diff

## Test plan

- [ ] Merge this PR
- [ ] Verify the release workflow runs and `update-docs` detects changed charts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)