### PR TITLE
fix(cert-manager-config): use managedIdentity.clientID for Azure Workload Identity

### DIFF
--- a/charts/cert-manager-config/templates/cluster-issuer-private.yaml
+++ b/charts/cert-manager-config/templates/cluster-issuer-private.yaml
@@ -20,14 +20,12 @@ spec:
             project: "{{ .Values.gcp.projectId }}"
           {{- else if eq .Values.cloudProvider "azure" }}
           azureDNS:
-            clientID: {{ .Values.azure.clientID }}
             subscriptionID: {{ .Values.azure.subscriptionID }}
-            tenantID: {{ .Values.azure.tenantID }}
             resourceGroupName: {{ .Values.azure.resourceGroupName }}
             hostedZoneName: {{ .Values.azure.hostedZoneName }}
             environment: AzurePublicCloud
-            config:
-              useWorkloadIdentityExtension: true
+            managedIdentity:
+              clientID: {{ required "azure.clientID is required" .Values.azure.clientID | quote }}
           {{- else if eq .Values.cloudProvider "cloudflare" }}
           cloudflare:
             apiTokenSecretRef:

--- a/charts/cert-manager-config/templates/cluster-issuer-private.yaml
+++ b/charts/cert-manager-config/templates/cluster-issuer-private.yaml
@@ -24,8 +24,16 @@ spec:
             resourceGroupName: {{ .Values.azure.resourceGroupName }}
             hostedZoneName: {{ .Values.azure.hostedZoneName }}
             environment: AzurePublicCloud
+            {{- if .Values.azure.useWorkloadIdentity }}
             managedIdentity:
               clientID: {{ required "azure.clientID is required" .Values.azure.clientID | quote }}
+            {{- else }}
+            tenantID: {{ required "azure.tenantID is required" .Values.azure.tenantID | quote }}
+            clientID: {{ required "azure.clientID is required" .Values.azure.clientID | quote }}
+            clientSecretSecretRef:
+              name: {{ required "azure.clientSecret.secretName is required" .Values.azure.clientSecret.secretName | quote }}
+              key: {{ .Values.azure.clientSecret.secretKey | default "client-secret" | quote }}
+            {{- end }}
           {{- else if eq .Values.cloudProvider "cloudflare" }}
           cloudflare:
             apiTokenSecretRef:

--- a/charts/cert-manager-config/templates/cluster-issuer-public.yaml
+++ b/charts/cert-manager-config/templates/cluster-issuer-public.yaml
@@ -23,8 +23,16 @@ spec:
             resourceGroupName: {{ required "azure.resourceGroupName is required" .Values.azure.resourceGroupName | quote }}
             hostedZoneName: {{ .Values.hostedZoneName }}
             environment: AzurePublicCloud
+            {{- if .Values.azure.useWorkloadIdentity }}
             managedIdentity:
               clientID: {{ required "azure.clientID is required" .Values.azure.clientID | quote }}
+            {{- else }}
+            tenantID: {{ required "azure.tenantID is required" .Values.azure.tenantID | quote }}
+            clientID: {{ required "azure.clientID is required" .Values.azure.clientID | quote }}
+            clientSecretSecretRef:
+              name: {{ required "azure.clientSecret.secretName is required" .Values.azure.clientSecret.secretName | quote }}
+              key: {{ .Values.azure.clientSecret.secretKey | default "client-secret" | quote }}
+            {{- end }}
           {{- else if eq .Values.cloudProvider "cloudflare" }}
           cloudflare:
             apiTokenSecretRef:

--- a/charts/cert-manager-config/templates/cluster-issuer-public.yaml
+++ b/charts/cert-manager-config/templates/cluster-issuer-public.yaml
@@ -23,8 +23,8 @@ spec:
             resourceGroupName: {{ required "azure.resourceGroupName is required" .Values.azure.resourceGroupName | quote }}
             hostedZoneName: {{ .Values.hostedZoneName }}
             environment: AzurePublicCloud
-            config:
-              useWorkloadIdentityExtension: true
+            managedIdentity:
+              clientID: {{ required "azure.clientID is required" .Values.azure.clientID | quote }}
           {{- else if eq .Values.cloudProvider "cloudflare" }}
           cloudflare:
             apiTokenSecretRef:

--- a/charts/cert-manager-config/values.yaml
+++ b/charts/cert-manager-config/values.yaml
@@ -12,6 +12,10 @@ azure:
   clientID: ""
   tenantID: ""
   hostedZoneName: ""
+  useWorkloadIdentity: true
+  clientSecret:
+    secretName: ""
+    secretKey: "client-secret"
 cloudflare:
   secretName: "cloudflare-api-token-secret"
   apiToken: ""


### PR DESCRIPTION
## Summary
- Replace invalid `config.useWorkloadIdentityExtension: true` with correct `managedIdentity.clientID` in `azureDNS` solver spec (both public and private ClusterIssuer)
- Remove invalid `clientID` and `tenantID` direct fields from `azureDNS` in the private issuer — those fields don't exist in cert-manager's spec for any auth method
- Add `azure.useWorkloadIdentity` (default: `true`) to support both Workload Identity and Service Principal auth methods

## Why
`config.useWorkloadIdentityExtension` is not a valid field in cert-manager's `azureDNS` spec. Any cluster using this had a ClusterIssuer that failed silently to issue certificates. The correct approach per [cert-manager docs](https://cert-manager.io/docs/configuration/acme/dns01/azuredns/) is `managedIdentity.clientID`.

## Compatibility
- **GCP, AWS, Cloudflare, OCI**: no impact — changes are inside `{{- if eq .Values.cloudProvider "azure" }}`
- **Azure WI** (`useWorkloadIdentity: true`, default): uses `managedIdentity.clientID` — requires cert-manager >= 1.8
- **Azure SP** (`useWorkloadIdentity: false`): uses `clientID` + `tenantID` + `clientSecretSecretRef` — requires `azure.clientSecret.secretName` to be set
- `azure.clientID` is now required when `cloudProvider=azure` — previously the field existed in `values.yaml` but was unused in the public issuer, causing silent failures

## Test plan
- [x] WI: deployed ClusterIssuer on AKS — status `Ready: True`, ACME account registered
- [x] SP: deployed ClusterIssuer with Service Principal + K8s secret — status `Ready: True`, ACME account registered
- [x] Switched between both modes on the same cluster without issues