### PR TITLE
fix(base): update bitnami/kubectl image tag from 1.31 to latest

### DIFF
--- a/charts/base/templates/daemonset.yaml
+++ b/charts/base/templates/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
       {{- if .Values.logging.ensureLease }}
       initContainers:
         - name: ensure-lease
-          image: bitnami/kubectl:1.31
+          image: bitnami/kubectl:latest
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## Summary

- The image tag `bitnami/kubectl:1.31` does not exist in Docker Hub, causing `ImagePullBackOff` / `ErrImagePull` errors in the `base` chart's `ensure-lease` init container
- Updated to `bitnami/kubectl:latest` (currently resolves to 1.35.4)

## Test plan

- [ ] Deploy `base` chart and verify the `ensure-lease` init container starts without image pull errors
- [ ] Confirm the Lease resource is created correctly in the target namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)