### PR TITLE
fix(base): replace ensureLease init container with pre-install hook Job

### DIFF
--- a/charts/base/templates/clusterrolebindings.yaml
+++ b/charts/base/templates/clusterrolebindings.yaml
@@ -56,3 +56,21 @@ subjects:
     name: nullplatform-crd-installer-sa
     namespace: {{ .Release.Namespace }}
 {{- end }}
+---
+{{- if .Values.logging.ensureLease }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nullplatform-lease-installer-binding
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nullplatform-lease-installer
+subjects:
+  - kind: ServiceAccount
+    name: nullplatform-lease-installer-sa
+    namespace: {{ .Values.namespaces.nullplatformTools }}
+{{- end }}

--- a/charts/base/templates/clusterroles.yaml
+++ b/charts/base/templates/clusterroles.yaml
@@ -41,3 +41,17 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "patch"]
+---
+{{- if .Values.logging.ensureLease }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nullplatform-lease-installer
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "patch"]
+{{- end }}

--- a/charts/base/templates/daemonset.yaml
+++ b/charts/base/templates/daemonset.yaml
@@ -29,24 +29,6 @@ spec:
       tolerations:
         {{- toYaml .Values.logging.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.logging.ensureLease }}
-      initContainers:
-        - name: ensure-lease
-          image: bitnami/kubectl:latest
-          command:
-            - /bin/sh
-            - -c
-            - |
-              kubectl apply -f - <<'EOF'
-              apiVersion: coordination.k8s.io/v1
-              kind: Lease
-              metadata:
-                name: nullplatform-metrics-extractor
-                namespace: {{ .Values.namespaces.nullplatformTools }}
-              spec:
-                holderIdentity: ""
-              EOF
-      {{- end }}
       containers:
         - name: nullplatform-log-controller
           image: {{ .Values.logging.controller.image }}

--- a/charts/base/templates/lease.yaml
+++ b/charts/base/templates/lease.yaml
@@ -1,9 +1,8 @@
 apiVersion: coordination.k8s.io/v1
 kind: Lease
 metadata:
-    name: nullplatform-metrics-extractor
-    namespace: nullplatform-tools
-spec:
-    holderIdentity: ""
-
-
+  name: nullplatform-metrics-extractor
+  namespace: {{ .Values.namespaces.nullplatformTools }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/charts/base/templates/pre-install-lease.yaml
+++ b/charts/base/templates/pre-install-lease.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.logging.ensureLease }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ensure-nullplatform-lease
+  namespace: {{ .Values.namespaces.nullplatformTools }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+spec:
+  template:
+    spec:
+      serviceAccountName: nullplatform-lease-installer-sa
+      containers:
+      - name: ensure-lease
+        image: docker.io/bitnami/kubectl:latest
+        command:
+          - /bin/sh
+          - -c
+          - |
+            kubectl apply -f - <<'EOF'
+            apiVersion: coordination.k8s.io/v1
+            kind: Lease
+            metadata:
+              name: nullplatform-metrics-extractor
+              namespace: {{ .Values.namespaces.nullplatformTools }}
+            EOF
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/base/templates/serviceaccount.yaml
+++ b/charts/base/templates/serviceaccount.yaml
@@ -14,3 +14,14 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-5"
 {{- end }}
+---
+{{- if .Values.logging.ensureLease }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nullplatform-lease-installer-sa
+  namespace: {{ .Values.namespaces.nullplatformTools }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+{{- end }}


### PR DESCRIPTION
## Problem

The `ensure-lease` init container in the `nullplatform-log-controller` DaemonSet pulls `bitnami/kubectl` from Docker Hub on every pod startup. Since a DaemonSet runs one pod per node, a cluster with N nodes triggers N image pulls per deploy — causing Docker Hub rate limit errors reported by customers.

Additionally, `lease.yaml` was a regular Helm template, causing Helm's SSA to conflict with the `k8s-logs-controller` over `holderIdentity` on every upgrade (revisions 3, 5 in minikube history showed this exact failure).

## Changes

- **`daemonset.yaml`**: Remove `ensure-lease` init container entirely — eliminates all Docker Hub pulls from the DaemonSet
- **`pre-install-lease.yaml`** (new): Hook Job (`pre-install,pre-upgrade`) that creates the Lease once per Helm operation, regardless of node count. Controlled by existing `logging.ensureLease` flag
- **`lease.yaml`**: Convert from regular template to `pre-install` hook — Helm creates it on install only, never SSA-applies it on upgrade. Removes `holderIdentity` from spec so the controller has full SSA ownership
- **`serviceaccount.yaml` / `clusterroles.yaml` / `clusterrolebindings.yaml`**: Add hook RBAC (`hook-weight: -5`) for the new Job SA

## ArgoCD compatibility

- Hook resources are excluded from ArgoCD's desired state — no more drift loop where ArgoCD fights the controller over `holderIdentity`
- The hook Job maps to ArgoCD's PreSync phase, which is the correct behavior (Lease exists before DaemonSet pods start)

## Test plan

- [x] `helm template --set logging.ensureLease=true` renders Job hook + RBAC, no `initContainers` in DaemonSet
- [x] `helm upgrade --set logging.ensureLease=true` on minikube — Job completes, Lease created (`lease.coordination.k8s.io/nullplatform-metrics-extractor configured`)
- [x] Two consecutive upgrades succeed without SSA conflict (previously failed on rev 3, 5, 8)
- [x] `helm template` (default `ensureLease=false`) renders zero lease-installer resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)