### PR TITLE
ci: skip branch-name and commitlint checks for dependabot PRs

### DIFF
--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   branch-name:
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: ${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot/') }}
     uses: nullplatform/actions-nullplatform/.github/workflows/branch-validation.yml@main
 
   commitlint:
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: ${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot/') }}
     uses: nullplatform/actions-nullplatform/.github/workflows/conventional-commit.yml@main
 
   lint-charts:


### PR DESCRIPTION
## Summary
- Agrega `!startsWith(github.head_ref, 'dependabot/')` a los jobs `branch-name` y `commitlint`
- Mismo patrón que ya existe para `release-please`
- `lint-charts` sigue corriendo normalmente para PRs de Dependabot

## Verificación
Mergear este PR y hacer `@dependabot rebase` en el PR #151.