### PR TITLE
feat(base): soporte de azure_load_balancer_subnet para el gateway público

### DIFF
--- a/charts/base/templates/gateways.yaml
+++ b/charts/base/templates/gateways.yaml
@@ -195,6 +195,9 @@ metadata:
     {{- else if eq .Values.global.provider "aks" }}
     {{- if eq .Values.gateway.public.loadBalancerType "internal" }}
     service.beta.kubernetes.io/azure-load-balancer-internal: 'true'
+    {{- if .Values.gateway.public.azure.subnet }}
+    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: {{ .Values.gateway.public.azure.subnet }}
+    {{- end }}
     {{- else }}
     service.beta.kubernetes.io/azure-load-balancer-internal: 'false'
     {{- end }}

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -94,6 +94,9 @@ gateway:
       # Network Security Group ID for the public gateway
       # If empty, Azure will create default rules
       networkSecurityGroup: ""
+      # Subnet name for the internal LB (only used when loadBalancerType is "internal")
+      # If empty, Azure picks the subnet automatically
+      subnet: ""
     # GCP-specific configuration (GKE)
     gcp:
       # Firewall rule name for the public gateway


### PR DESCRIPTION
## Qué

Agrega `gateway.public.azure.subnet` al chart base para que el LB interno del gateway **público** pueda fijarse a una subnet específica en AKS — capacidad que el gateway **interno** ya tiene (vía `gateway.internal.azure_load_balancer_subnet`).

Se modela **anidado bajo el bloque `public.azure`** (junto a `networkSecurityGroup`), de forma simétrica a cómo OCI anida su subnet bajo `public.oci`.

## Por qué

Cuando el gateway público se configura con `loadBalancerType: internal` (el tráfico entra por una vía privada, p. ej. detrás de un túnel/proxy en la VNet), el chart solo emite:

```yaml
service.beta.kubernetes.io/azure-load-balancer-internal: 'true'
```

…pero **no** la anotación de subnet. Azure entonces elige la subnet del LB automáticamente, que puede no ser la deseada. Hoy esto hay que parchearlo por fuera con un recurso `kubernetes_annotations`. Este cambio cierra esa brecha.

## Cambios

- `values.yaml`: nuevo `gateway.public.azure.subnet` (vacío por defecto).
- `templates/gateways.yaml`: emite `service.beta.kubernetes.io/azure-load-balancer-internal-subnet` en el gateway público **solo cuando** el valor está seteado y `loadBalancerType: internal`.

## Retrocompatibilidad

Sin cambio de comportamiento cuando el valor queda vacío — la anotación está protegida por `{{- if .Values.gateway.public.azure.subnet }}`.

## Verificación

`helm template` con `global.provider=aks` y `gateway.public.loadBalancerType=internal`:

- **`gateway.public.azure.subnet` seteada** → emite `azure-load-balancer-internal-subnet: <subnet>` ✅
- **vacía (default)** → anotación omitida ✅