### PR TITLE
feat(agent chart): worker orchestration config + scoped worker RBAC

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nullplatform-agent
 description: Agent used to interact with services, scopes and telemetry inside a cluster
 type: application
-version: 2.35.0
+version: 2.36.0
 appVersion: 2.32.1
 keywords:
   - nullplatform

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -82,10 +82,19 @@ The agent reads these (os.Getenv) to pick the backend and shape worker pods.
   value: {{ .security | default "mtls" | quote }}
 - name: NP_WORKER_NAMESPACE
   value: {{ .namespace | default $.Values.namespace | quote }}
-{{- if .workers }}
-- name: NP_WORKERS
-  value: {{ .workers | toJson | quote }}
+{{- if .allowedRegistries }}
+- name: NP_ALLOWED_REGISTRIES
+  value: {{ join "," .allowedRegistries | quote }}
 {{- end }}
+{{- if .pins }}
+- name: NP_WORKERS
+  value: {{ .pins | toJson | quote }}
+{{- end }}
+{{- if .rules }}
+- name: NP_WORKER_RULES
+  value: {{ .rules | toJson | quote }}
+{{- end }}
+{{- with .defaults }}
 {{- if .serviceAccount }}
 - name: NP_WORKER_SERVICE_ACCOUNT
   value: {{ .serviceAccount | quote }}
@@ -128,5 +137,6 @@ The agent reads these (os.Getenv) to pick the backend and shape worker pods.
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}
+{{- end }}{{/* end with .defaults */}}
+{{- end }}{{/* end with .Values.worker */}}
 {{- end -}}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -82,6 +82,10 @@ The agent reads these (os.Getenv) to pick the backend and shape worker pods.
   value: {{ .security | default "mtls" | quote }}
 - name: NP_WORKER_NAMESPACE
   value: {{ .namespace | default $.Values.namespace | quote }}
+{{- if .workers }}
+- name: NP_WORKERS
+  value: {{ .workers | toJson | quote }}
+{{- end }}
 {{- if .serviceAccount }}
 - name: NP_WORKER_SERVICE_ACCOUNT
   value: {{ .serviceAccount | quote }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -78,6 +78,8 @@ The agent reads these (os.Getenv) to pick the backend and shape worker pods.
 {{- with .Values.worker }}
 - name: NP_WORKER_BACKEND
   value: {{ .backend | default "kubernetes" | quote }}
+- name: NP_WORKER_SECURITY
+  value: {{ .security | default "mtls" | quote }}
 {{- if .namespace }}
 - name: NP_WORKER_NAMESPACE
   value: {{ .namespace | quote }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -80,10 +80,8 @@ The agent reads these (os.Getenv) to pick the backend and shape worker pods.
   value: {{ .backend | default "kubernetes" | quote }}
 - name: NP_WORKER_SECURITY
   value: {{ .security | default "mtls" | quote }}
-{{- if .namespace }}
 - name: NP_WORKER_NAMESPACE
-  value: {{ .namespace | quote }}
-{{- end }}
+  value: {{ .namespace | default $.Values.namespace | quote }}
 {{- if .serviceAccount }}
 - name: NP_WORKER_SERVICE_ACCOUNT
   value: {{ .serviceAccount | quote }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -60,3 +60,69 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Join a map into "k1=v1,k2=v2" for the agent's NP_WORKER_* env vars.
+*/}}
+{{- define "agent.kvJoin" -}}
+{{- $pairs := list -}}
+{{- range $k, $v := . -}}{{- $pairs = append $pairs (printf "%s=%s" $k $v) -}}{{- end -}}
+{{- join "," $pairs -}}
+{{- end -}}
+
+{{/*
+Render the worker orchestrator config as NP_WORKER_* env for the agent container.
+The agent reads these (os.Getenv) to pick the backend and shape worker pods.
+*/}}
+{{- define "agent.workerEnv" -}}
+{{- with .Values.worker }}
+- name: NP_WORKER_BACKEND
+  value: {{ .backend | default "kubernetes" | quote }}
+{{- if .namespace }}
+- name: NP_WORKER_NAMESPACE
+  value: {{ .namespace | quote }}
+{{- end }}
+{{- if .serviceAccount }}
+- name: NP_WORKER_SERVICE_ACCOUNT
+  value: {{ .serviceAccount | quote }}
+{{- end }}
+{{- if .nodeSelector }}
+- name: NP_WORKER_NODE_SELECTOR
+  value: {{ include "agent.kvJoin" .nodeSelector | quote }}
+{{- end }}
+{{- if .labels }}
+- name: NP_WORKER_LABELS
+  value: {{ include "agent.kvJoin" .labels | quote }}
+{{- end }}
+{{- if .imagePullSecrets }}
+- name: NP_WORKER_IMAGE_PULL_SECRETS
+  value: {{ join "," .imagePullSecrets | quote }}
+{{- end }}
+{{- if .env }}
+- name: NP_WORKER_ENV
+  value: {{ include "agent.kvJoin" .env | quote }}
+{{- end }}
+{{- with .resources }}
+{{- with .requests }}
+{{- if .cpu }}
+- name: NP_WORKER_CPU_REQUEST
+  value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+- name: NP_WORKER_MEM_REQUEST
+  value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
+{{- with .limits }}
+{{- if .cpu }}
+- name: NP_WORKER_CPU_LIMIT
+  value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+- name: NP_WORKER_MEM_LIMIT
+  value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -151,6 +151,7 @@ spec:
             - name: INIT_SCRIPTS_CONFIGMAP
               value: "init-scripts-{{ .Release.Name }}"
             {{- end }}
+            {{- include "agent.workerEnv" . | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ .Values.configuration.secretName }}-{{ .Release.Name }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -122,9 +122,14 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.args }}
+          {{- if or .Values.args .Values.extraArgs }}
           args:
+          {{- with .Values.args }}
           {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraArgs }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -122,14 +122,9 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if or .Values.args .Values.extraArgs }}
-          args:
           {{- with .Values.args }}
+          args:
           {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.extraArgs }}
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/agent/templates/statefulset.yaml
+++ b/charts/agent/templates/statefulset.yaml
@@ -43,9 +43,14 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.args }}
+          {{- if or .Values.args .Values.extraArgs }}
           args:
+          {{- with .Values.args }}
           {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraArgs }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/agent/templates/statefulset.yaml
+++ b/charts/agent/templates/statefulset.yaml
@@ -43,14 +43,9 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if or .Values.args .Values.extraArgs }}
-          args:
           {{- with .Values.args }}
+          args:
           {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.extraArgs }}
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/agent/templates/statefulset.yaml
+++ b/charts/agent/templates/statefulset.yaml
@@ -66,6 +66,7 @@ spec:
             - name: INIT_SCRIPTS_CONFIGMAP
               value: "init-scripts-{{ .Release.Name }}"
             {{- end }}
+            {{- include "agent.workerEnv" . | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ .Values.configuration.secretName }}-{{ .Release.Name }}

--- a/charts/agent/templates/worker-networkpolicy.yaml
+++ b/charts/agent/templates/worker-networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- /*
+Restrict worker pods so ONLY the agent may reach their gRPC port — defense in
+depth on top of the agent↔worker mTLS. Requires a CNI that enforces
+NetworkPolicy (Calico, Cilium, EKS/GKE/AKS policy modes). Kubernetes backend only.
+*/ -}}
+{{- if and (eq .Values.worker.backend "kubernetes") .Values.worker.networkPolicy.create }}
+{{- $ns := default .Values.namespace .Values.worker.namespace }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "agent.fullname" . }}-worker
+  namespace: {{ $ns }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+spec:
+  # Applies to every worker the agent creates.
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: np-agent
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Only the agent pod, in the agent's namespace, may connect.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.namespace }}
+          podSelector:
+            matchLabels:
+              {{- include "agent.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.worker.grpcPort | default 50051 }}
+{{- end }}

--- a/charts/agent/templates/worker-rbac.yaml
+++ b/charts/agent/templates/worker-rbac.yaml
@@ -1,0 +1,35 @@
+{{- /*
+Least-privilege RBAC for the agent to manage worker Deployments/Services/Pods/
+ConfigMaps in the worker namespace. Enable when the agent's own RBAC is scoped
+down from cluster-wide (serviceAccount.clusterWide: false) — the default broad
+role already covers this, so this is opt-in.
+*/ -}}
+{{- if .Values.worker.rbac.create }}
+{{- $ns := default .Values.namespace .Values.worker.namespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}-worker
+  namespace: {{ $ns }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "pods", "configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}-worker
+  namespace: {{ $ns }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agent.serviceAccountName" . }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agent.serviceAccountName" . }}-worker
+{{- end }}

--- a/charts/agent/templates/worker-rbac.yaml
+++ b/charts/agent/templates/worker-rbac.yaml
@@ -16,7 +16,7 @@ rules:
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
-    resources: ["services", "pods", "configmaps"]
+    resources: ["services", "pods", "configmaps", "secrets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -65,24 +65,15 @@ serviceAccount:
   name: nullplatform-agent
   # Set to true for cluster-wide access (ClusterRole), false for namespace-scoped access (Role)
   clusterWide: true
-  # Scoped to what the agent actually needs: orchestrating worker
-  # Deployments/Services/Pods/Secrets/ConfigMaps and reading pod logs. Extend
-  # `rules` here if your deployment uses agent features that need more access —
-  # this is deliberately NOT cluster-admin (`*/*/*`) by default.
   role:
     rules:
-      - apiGroups: ["apps"]
-        resources: ["deployments"]
-        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-      - apiGroups: [""]
-        resources: ["services", "pods", "configmaps", "secrets"]
-        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-      - apiGroups: [""]
-        resources: ["pods/log"]
-        verbs: ["get", "list"]
-      - apiGroups: [""]
-        resources: ["events"]
-        verbs: ["create", "patch"]
+      - apiGroups:
+          - '*'
+          - ""
+        resources:
+          - '*'
+        verbs:
+          - '*'
 
 podAnnotations:
   name: nullplatform-agent

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -182,3 +182,40 @@ imagePullSecret:
   # registry: ""
   # username: ""
   # password: ""
+
+# ── Worker orchestration ─────────────────────────────────────────────────────
+# The agent spawns package workers (lean gRPC servers) and streams actions to
+# them over gRPC — no separate controller. This block controls how workers
+# deploy; per-package overrides let you tune any field per package.
+worker:
+  # backend: kubernetes (agent creates Deployment+Service per package) |
+  #          docker (agent runs host containers)
+  backend: kubernetes
+  # namespace workers are created in (empty = the agent's namespace)
+  namespace: ""
+  # gRPC port every worker listens on (NP_GRPC_LISTEN)
+  grpcPort: 50051
+  # ── pod template applied to every worker ──
+  serviceAccount: ""        # SA for worker pods (empty = namespace default)
+  nodeSelector: {}
+  labels: {}
+  imagePullSecrets: []      # names of existing pull secrets
+  env: {}                   # env added to every worker
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
+  # ── per-package overrides, keyed by package slug (any field above) ──
+  overrides: {}
+    # postgres:
+    #   replicas: 2
+    #   resources:
+    #     limits: { memory: "512Mi" }
+    #   nodeSelector: { workload: db }
+  # RBAC letting the agent manage worker Deployments/Services/Pods/ConfigMaps in
+  # `namespace`. Enable when you scope the agent's own RBAC down from cluster-wide.
+  rbac:
+    create: false

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -33,20 +33,22 @@ args:
   - "--apikey=$(NP_API_KEY)"
   - "--runtime=host"
   - "--command-executor-env=NP_API_KEY=$(NP_API_KEY)"
-  - "--command-executor-debug"
   - "--webserver-enabled"
-  - "--command-executor-git-command-repos $(AGENT_REPO)"
+# Optional extra args. Add git-command-repos ONLY if you use them, as two
+# separate list items so an empty value can't corrupt flag parsing:
+#   - "--command-executor-git-command-repos"
+#   - "$(AGENT_REPO)"
+# And "--command-executor-debug" only when debugging (verbose; off by default).
+extraArgs: []
 
 configuration:
   create: true
   secretName: nullplatform-agent-secret
   values:
-    TAGS: "gato:negro"
-    NP_LOG_LEVEL: DEBUG
+    # Set the tags the platform routes to this agent (e.g. "package:my-scope").
+    TAGS: ""
+    NP_LOG_LEVEL: INFO
     NP_API_KEY: ""
-      # example:
-    # AGENT_REPO: "https://reppo_01.gt#main,https://token@repo_01.git#main"
-    AGENT_REPO: ""
 
 image:
   repository: public.ecr.aws/nullplatform/controlplane-agent
@@ -63,15 +65,24 @@ serviceAccount:
   name: nullplatform-agent
   # Set to true for cluster-wide access (ClusterRole), false for namespace-scoped access (Role)
   clusterWide: true
+  # Scoped to what the agent actually needs: orchestrating worker
+  # Deployments/Services/Pods/Secrets/ConfigMaps and reading pod logs. Extend
+  # `rules` here if your deployment uses agent features that need more access —
+  # this is deliberately NOT cluster-admin (`*/*/*`) by default.
   role:
     rules:
-      - apiGroups:
-          - '*'
-          - ""
-        resources:
-          - '*'
-        verbs:
-          - '*'
+      - apiGroups: ["apps"]
+        resources: ["deployments"]
+        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - apiGroups: [""]
+        resources: ["services", "pods", "configmaps", "secrets"]
+        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get", "list"]
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["create", "patch"]
 
 podAnnotations:
   name: nullplatform-agent
@@ -206,12 +217,31 @@ worker:
   namespace: ""
   # gRPC port every worker listens on (NP_GRPC_LISTEN)
   grpcPort: 50051
-  # ── pod template applied to every worker ──
-  serviceAccount: ""        # SA for worker pods (empty = namespace default)
+  # ── the workers this agent serves (rendered as NP_WORKERS) ──
+  # Each entry is one worker: package + version + image, plus a FEW optional
+  # per-worker overrides for when a worker's deployment differs (its own
+  # serviceAccount/permissions, resources, env, namespace, …). Anything omitted
+  # inherits the shared defaults below. The agent matches a package-exec's
+  # (package, version) here: exact (package, version) wins, else the package's
+  # no-version entry. Leave empty for a single-package agent pinning
+  # NP_WORKER_IMAGE instead.
+  workers: []
+    # - package: my-scope
+    #   version: "0.0.7"
+    #   image: ghcr.io/org/my-scope:0.0.7
+    #   serviceAccount: my-scope-sa      # this worker's own permissions
+    # - package: heavy-scope
+    #   version: "1.2.0"
+    #   image: ghcr.io/org/heavy:1.2.0
+    #   serviceAccount: heavy-sa
+    #   resources: { limits: { memory: "1Gi" } }
+  # ── shared defaults inherited by every worker (override per-worker above) ──
+  serviceAccount: ""        # default SA for worker pods (empty = namespace default)
   nodeSelector: {}
   labels: {}
   imagePullSecrets: []      # names of existing pull secrets
-  env: {}                   # env added to every worker
+  env: {}                   # extra env for every worker (NP_API_KEY + the cluster
+                            # CA trust are handled by the agent automatically)
   resources:
     requests:
       cpu: "50m"
@@ -219,14 +249,7 @@ worker:
     limits:
       cpu: "500m"
       memory: "256Mi"
-  # ── per-package overrides, keyed by package slug (any field above) ──
-  overrides: {}
-    # postgres:
-    #   replicas: 2
-    #   resources:
-    #     limits: { memory: "512Mi" }
-    #   nodeSelector: { workload: db }
-  # RBAC letting the agent manage worker Deployments/Services/Pods/ConfigMaps in
+  # RBAC letting the agent manage worker Deployments/Services/Pods/Secrets in
   # `namespace`. Enable when you scope the agent's own RBAC down from cluster-wide.
   rbac:
     create: false

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -196,8 +196,12 @@ imagePullSecret:
 
 # ── Worker orchestration ─────────────────────────────────────────────────────
 # The agent spawns package workers (lean gRPC servers) and streams actions to
-# them over gRPC — no separate controller. This block controls how workers
-# deploy; per-package overrides let you tune any field per package.
+# them over gRPC — no separate controller.
+#
+# Priority when a package-exec arrives:
+#   pins (an exact worker you control, trusted)  >  rules (config for a matched
+#   class)  >  defaults (every worker).  allowedRegistries gates every image that
+#   is resolved DYNAMICALLY (i.e. not from a pin) — deny-by-default.
 worker:
   # backend: kubernetes (agent creates Deployment+Service per package) |
   #          docker (agent runs host containers)
@@ -217,38 +221,57 @@ worker:
   namespace: ""
   # gRPC port every worker listens on (NP_GRPC_LISTEN)
   grpcPort: 50051
-  # ── the workers this agent serves (rendered as NP_WORKERS) ──
-  # Each entry is one worker: package + version + image, plus a FEW optional
-  # per-worker overrides for when a worker's deployment differs (its own
-  # serviceAccount/permissions, resources, env, namespace, …). Anything omitted
-  # inherits the shared defaults below. The agent matches a package-exec's
-  # (package, version) here: exact (package, version) wins, else the package's
-  # no-version entry. Leave empty for a single-package agent pinning
-  # NP_WORKER_IMAGE instead.
-  workers: []
+
+  # ── allowedRegistries — the guardrail (rendered as NP_ALLOWED_REGISTRIES) ──
+  # Deny-by-default: a worker whose image is resolved DYNAMICALLY from the action
+  # (not pinned below) only spawns when its image matches one of these globs.
+  # '*' matches any characters, including '/'. An empty list means nothing
+  # dynamic runs (only pins do) — set this, or every package-exec is refused.
+  allowedRegistries: []
+    # - "ghcr.io/your-org/*"
+    # - "*.dkr.ecr.us-east-1.amazonaws.com/your-org/*"
+
+  # ── defaults — config inherited by EVERY worker (rendered as NP_WORKER_*) ──
+  defaults:
+    serviceAccount: ""      # default SA for worker pods (empty = namespace default)
+    nodeSelector: {}
+    labels: {}
+    imagePullSecrets: []    # names of existing pull secrets
+    env: {}                 # extra env for every worker (NP_API_KEY + the cluster
+                            # CA trust are handled by the agent automatically)
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+
+  # ── rules — config for a matched CLASS of dynamic workers (NP_WORKER_RULES) ──
+  # First match wins. `match` globs the image registry/repository, the package
+  # slug, and/or the version; an empty field is a wildcard and an empty match is
+  # a catch-all. A rule supplies pod config only — the image stays dynamic.
+  rules: []
+    # - match: { registry: "*.dkr.ecr.us-east-1.amazonaws.com/*" }
+    #   imagePullSecrets: [ecr-pull]
+    # - match: { package: "heavy-*" }
+    #   resources: { limits: { memory: "2Gi" } }
+
+  # ── pins — EXACT workers you control (rendered as NP_WORKERS) ──
+  # Highest priority, and a pin's image is TRUSTED (bypasses allowedRegistries).
+  # Matched by exact (package, version), else the package's no-version pin. Each
+  # pin may carry its own per-worker overrides (own serviceAccount/RBAC, resources,
+  # env, namespace, …); anything omitted inherits `defaults`.
+  pins: []
     # - package: my-scope
     #   version: "0.0.7"
     #   image: ghcr.io/org/my-scope:0.0.7
-    #   serviceAccount: my-scope-sa      # this worker's own permissions
+    #   serviceAccount: my-scope-sa
     # - package: heavy-scope
     #   version: "1.2.0"
     #   image: ghcr.io/org/heavy:1.2.0
-    #   serviceAccount: heavy-sa
     #   resources: { limits: { memory: "1Gi" } }
-  # ── shared defaults inherited by every worker (override per-worker above) ──
-  serviceAccount: ""        # default SA for worker pods (empty = namespace default)
-  nodeSelector: {}
-  labels: {}
-  imagePullSecrets: []      # names of existing pull secrets
-  env: {}                   # extra env for every worker (NP_API_KEY + the cluster
-                            # CA trust are handled by the agent automatically)
-  resources:
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
-    limits:
-      cpu: "500m"
-      memory: "256Mi"
+
   # RBAC letting the agent manage worker Deployments/Services/Pods/Secrets in
   # `namespace`. Enable when you scope the agent's own RBAC down from cluster-wide.
   rbac:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -33,22 +33,20 @@ args:
   - "--apikey=$(NP_API_KEY)"
   - "--runtime=host"
   - "--command-executor-env=NP_API_KEY=$(NP_API_KEY)"
+  - "--command-executor-debug"
   - "--webserver-enabled"
-# Optional extra args. Add git-command-repos ONLY if you use them, as two
-# separate list items so an empty value can't corrupt flag parsing:
-#   - "--command-executor-git-command-repos"
-#   - "$(AGENT_REPO)"
-# And "--command-executor-debug" only when debugging (verbose; off by default).
-extraArgs: []
+  - "--command-executor-git-command-repos $(AGENT_REPO)"
 
 configuration:
   create: true
   secretName: nullplatform-agent-secret
   values:
-    # Set the tags the platform routes to this agent (e.g. "package:my-scope").
-    TAGS: ""
-    NP_LOG_LEVEL: INFO
+    TAGS: "gato:negro"
+    NP_LOG_LEVEL: DEBUG
     NP_API_KEY: ""
+      # example:
+    # AGENT_REPO: "https://reppo_01.gt#main,https://token@repo_01.git#main"
+    AGENT_REPO: ""
 
 image:
   repository: public.ecr.aws/nullplatform/controlplane-agent

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -191,6 +191,17 @@ worker:
   # backend: kubernetes (agent creates Deployment+Service per package) |
   #          docker (agent runs host containers)
   backend: kubernetes
+  # security between the agent and its workers:
+  #   mtls     – agent mints a per-process CA, hands each worker a cert, and dials
+  #              with a client cert (only the agent can call the worker, encrypted).
+  #              No external CA / cert-manager / service mesh. (default, recommended)
+  #   insecure – plaintext, no auth. Only if the path is already secured elsewhere.
+  security: mtls
+  # NetworkPolicy so ONLY the agent may reach worker pods (needs a CNI that
+  # enforces NetworkPolicy — Calico/Cilium/EKS/GKE/AKS). Defense in depth on top
+  # of mTLS. Applies to the kubernetes backend.
+  networkPolicy:
+    create: true
   # namespace workers are created in (empty = the agent's namespace)
   namespace: ""
   # gRPC port every worker listens on (NP_GRPC_LISTEN)


### PR DESCRIPTION
charts/agent gains a worker: block (backend, gRPC port, pod template: SA/nodeSelector/labels/env/resources/imagePullSecrets, per-package overrides) and an opt-in least-privilege Role/RoleBinding for the agent to manage worker Deployments/Services/Pods/ConfigMaps.