### PR TITLE
feat(base): support IRSA annotations on logs controller SA when cloudwatch enabled

### DIFF
--- a/charts/base/README.md
+++ b/charts/base/README.md
@@ -43,6 +43,7 @@ helm install nullplatform-base nullplatform/nullplatform-base
 | cloudwatch.performanceMetrics.enabled | bool | `true` |  |
 | cloudwatch.region | string | `"us-east-1"` |  |
 | cloudwatch.retentionDays | int | `7` |  |
+| cloudwatch.serviceAccount.annotations | object | `{}` | Annotations added to the logs controller ServiceAccount (nullplatform-pod-metadata-reader-sa) when cloudwatch.enabled is true; set eks.amazonaws.com/role-arn here to use IRSA |
 | controlPlane.agent.image | string | `"public.ecr.aws/nullplatform/controlplane-agent:latest"` |  |
 | controlPlane.agent.resources.limits.cpu | string | `"100m"` |  |
 | controlPlane.agent.resources.limits.memory | string | `"150Mi"` |  |

--- a/charts/base/templates/serviceaccount.yaml
+++ b/charts/base/templates/serviceaccount.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: nullplatform-pod-metadata-reader-sa
   namespace: {{ .Values.namespaces.nullplatformTools }}
+  {{- if and .Values.cloudwatch.enabled .Values.cloudwatch.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.cloudwatch.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 ---
 {{- if .Values.global.installGatewayV2Crd }}
 apiVersion: v1

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -218,6 +218,14 @@ cloudwatch:
     enabled: true
   accessLogs:
     enabled: false
+  # ServiceAccount settings for the logs controller (nullplatform-pod-metadata-reader-sa).
+  # Annotations are only rendered when cloudwatch.enabled is true. Set the IRSA role
+  # ARN here to let the logs controller reach CloudWatch via a scoped IAM role instead
+  # of the node instance role, e.g.:
+  #   annotations:
+  #     eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<role-name>
+  serviceAccount:
+    annotations: {}
 # Metrics server configuration
 metricsServer:
   enabled: true


### PR DESCRIPTION
## What

Renders `annotations` on the `nullplatform-pod-metadata-reader-sa` ServiceAccount **only when** `cloudwatch.enabled` is true **and** `cloudwatch.serviceAccount.annotations` is non-empty. Adds the `cloudwatch.serviceAccount.annotations` value (default `{}`).

No change for existing installs: with cloudwatch disabled or no annotations set, the SA renders exactly as before.

## Why

The logs controller (`k8s-logs-controller`) runs under `nullplatform-pod-metadata-reader-sa`. The SA had no annotations and no way to set them via values, so on EKS the controller could only reach CloudWatch through the **node instance role** (broad, node-wide privilege).

This lets you set `eks.amazonaws.com/role-arn` on the SA and use **IRSA** — a scoped IAM role for just the logs controller — instead of granting CloudWatch to every pod on the node.

## Changes

- `templates/serviceaccount.yaml` — conditional `annotations` block on the reader SA
- `values.yaml` — new `cloudwatch.serviceAccount.annotations` (default `{}`) with documented example
- `README.md` — values table entry

## Usage

```yaml
cloudwatch:
  enabled: true
  serviceAccount:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<role-name>
```

## Testing

`helm template` verified in three scenarios:
- cloudwatch disabled → SA has no annotations
- cloudwatch enabled + role-arn → annotation rendered with correct indentation
- cloudwatch enabled + empty map → no empty `annotations:` block (valid YAML)

> Paired with the tofu-modules change that passes this value through the `base` module: https://github.com/nullplatform/tofu-modules/pull/441

🤖 Generated with [Claude Code](https://claude.com/claude-code)