### PR TITLE
fix(base): match gateway PDB selector to the generated pod label

### DIFF
--- a/charts/base/templates/gateways.yaml
+++ b/charts/base/templates/gateways.yaml
@@ -157,9 +157,10 @@ metadata:
 spec:
   maxUnavailable: 50%
   selector:
-    # Match the generated Deployment by label
+    # Selects the gateway PODS by the label the Gateway API controller sets on them:
+    # the Gateway's own name, not the "-istio" Deployment name. Same key as istio-metrics.
     matchLabels:
-      istio.io/gateway-name: {{ .Values.gateway.internal.name }}
+      gateway.networking.k8s.io/gateway-name: {{ .Values.gateway.internal.name }}
 ---
 {{- end }}
 {{- if and .Values.gateways.enabled .Values.gateway.public.enabled }}
@@ -303,9 +304,10 @@ metadata:
 spec:
   maxUnavailable: 50%
   selector:
-    # Match the generated Deployment by label
+    # Selects the gateway PODS by the label the Gateway API controller sets on them:
+    # the Gateway's own name, not the "-istio" Deployment name. Same key as istio-metrics.
     matchLabels:
-      istio.io/gateway-name: {{ .Values.gateway.public.name }}
+      gateway.networking.k8s.io/gateway-name: {{ .Values.gateway.public.name }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Problem

Both gateway PodDisruptionBudgets in `charts/base` select on `istio.io/gateway-name`, but the Deployments generated by Istio's Gateway API controller label their pods with `gateway.networking.k8s.io/gateway-name`.

The selector matches zero pods, so both PDBs report an empty budget while the Deployments are perfectly healthy. Observed on a live cluster running this chart:

```console
$ kubectl get pdb -n gateways -o custom-columns=\
NAME:.metadata.name,HEALTHY:.status.currentHealthy,DESIRED:.status.desiredHealthy,ALLOWED:.status.disruptionsAllowed
NAME              HEALTHY   DESIRED   ALLOWED
gateway-private   0         0         0
gateway-public    0         0         0

$ kubectl get deploy -n gateways
NAME                    READY   UP-TO-DATE   AVAILABLE
gateway-private-istio   2/2     2            2
gateway-public-istio    2/2     2            2
```

`HEALTHY: 0` against `READY: 2/2` is the tell: the selector resolves to an empty pod set. The pods carry the Gateway API label instead:

```console
$ kubectl get pods -n gateways --show-labels
gateway-private-istio-78d744867c-kpgz6   ...,gateway.networking.k8s.io/gateway-name=gateway-private,...
gateway-public-istio-6bc49d4d64-hnl4k    ...,gateway.networking.k8s.io/gateway-name=gateway-public,...
```

A PDB that matches nothing protects nothing: the gateways have no real disruption budget during node drains or upgrades, while appearing to be covered.

## Fix

Point both selectors at `gateway.networking.k8s.io/gateway-name`.

The label **value** was already correct and is unchanged: per the Gateway API convention the generated pods carry the *Gateway object's* name, not the `-istio` Deployment name — so only the key was wrong.

This is the key the `istio-metrics` chart in this repository already uses (`charts/istio-metrics/templates/istio-metrics-config.yaml`), and its `NOTES.txt` states it explicitly:

> Gateway pods must be labeled with: `gateway.networking.k8s.io/gateway-name`

So `base` was the outlier against a convention this repo already documents.

The comment above both selectors is corrected too. It read `# Match the generated Deployment by label`, echoing the accurate HPA comment a few lines above (`# Match the generated Deployment by reference`, which really does reference the Deployment via `scaleTargetRef`). A PDB selector matches Pods and never looks at the Deployment, so the comment described the wrong mechanism — plausibly the mental model that produced this bug.

## Verification

- `helm template` renders `gateway.networking.k8s.io/gateway-name: gateway-private` / `gateway-public`, matching the live pod labels shown above.
- `helm lint charts/base`: 1 chart linted, 0 failed.
- **`helm lint` cannot catch this bug class** — it returns an identical clean result with the old, zero-matching key. Same for `ct lint`. A `matchLabels` entry with an arbitrary key is valid API shape regardless of whether any pod carries it, so nothing in CI would have flagged this, and nothing would flag a regression. Worth knowing when reviewing.
- No version bump included — `Chart.yaml` is owned by release-please.

## Heads-up: these PDBs go from vacuous to enforcing

This is the intended outcome, but it is a behavioral change worth flagging for anyone rolling out this chart version.

With the default `autoscaling.minReplicas: 2`, `maxUnavailable: 50%` allows exactly one gateway pod to be evicted at a time — which is the point of the fix.

However, `minReplicas` is overridable per gateway and there is no `values.schema.json` enforcing a floor. **If a gateway runs at 1 replica, Kubernetes rounds `maxUnavailable` percentages down** — `floor(0.5 × 1) = 0` — so the PDB flips from no-op to permanently blocking voluntary evictions on that pod: `kubectl drain`, autoscaler consolidation and managed node group upgrades will stall indefinitely.

Before rolling this out, check `minReplicas >= 2` on each enabled gateway. Diagnose a stalled drain with:

```console
kubectl get pdb -A -o custom-columns=NAME:.metadata.name,ALLOWED:.status.disruptionsAllowed
```

## Note for anyone debugging a stuck node drain

Because these PDBs currently match nothing, they also surface as `disruptionsAllowed: 0` and look like the cause of a blocked eviction. Today they are not. The usual culprit is the `istiod` PDB: with a single istiod replica, `minAvailable: 1` leaves `disruptionsAllowed` permanently at 0 and no drain can complete. Worth keeping in mind so this fix is not mistaken for a drain fix — and note that after this change a 1-replica gateway can reproduce the same failure mode, per the section above.
