### PR TITLE
fix(base): stop the namespaces from deleting themselves on upgrade

### DIFF
--- a/charts/base/templates/gateways.yaml
+++ b/charts/base/templates/gateways.yaml
@@ -15,6 +15,11 @@ metadata:
   name: {{ .Values.namespaces.gateway }}
   labels:
     name: {{ .Values.namespaces.gateway }}
+  annotations:
+    # The lookup above renders this Namespace only while it is absent, so the
+    # very next upgrade drops it from the manifest and Helm deletes it -- taking
+    # the Gateways, HPAs and PDBs inside it along. This keeps it alive.
+    helm.sh/resource-policy: keep
 {{- end }}
 ---
 {{- if and .Values.gateways.enabled .Values.gateway.internal.enabled }}

--- a/charts/base/templates/namespace.yaml
+++ b/charts/base/templates/namespace.yaml
@@ -7,6 +7,10 @@ metadata:
     name: {{ .Values.namespaces.nullplatformTools }}
   annotations:
     openshift.io/cluster-monitoring: "true"
+    # See the note on the gateway namespace: the lookup guard makes this
+    # Namespace disappear from the manifest on the first upgrade after it
+    # exists, which Helm reads as a delete.
+    helm.sh/resource-policy: keep
 {{- end }}
 ---
 {{- if not (lookup "v1" "Namespace" "" .Values.namespaces.nullplatformApplications) }}
@@ -16,5 +20,8 @@ metadata:
   name: {{ .Values.namespaces.nullplatformApplications }}
   labels:
     name: {{ .Values.namespaces.nullplatformApplications }}
+  annotations:
+    # Same guard, same hazard: this one holds every running application.
+    helm.sh/resource-policy: keep
 {{- end }}
 ---


### PR DESCRIPTION
## What happened

A routine `helm upgrade` of `nullplatform-base` on a live AKS cluster deleted the **`gateways` namespace** — taking both Gateways, their HPAs and PDBs, the pods and the public LoadBalancer with it. The chart still renders the Gateways *into* that namespace, so they came back up with nowhere to live.

## Why

All three namespaces the chart can create are guarded by a `lookup`:

```gotemplate
{{- if not (lookup "v1" "Namespace" "" .Values.namespaces.gateway) }}
apiVersion: v1
kind: Namespace
```

`lookup` queries the live cluster at render time, so the Namespace is emitted **only while it is absent**. That is self-destructing under Helm's declarative model:

| | lookup finds it? | rendered? | Helm's reading |
|---|---|---|---|
| install | no | yes | owned by the release |
| **first upgrade** | **yes** | **no** | **removed from the manifest → delete it** |

The intent — "create it only if it isn't there" — is not expressible this way. Once a resource enters the release manifest, dropping it from a later render *means* delete.

This is **not tied to a version bump**: the templates are byte-identical across the releases involved. Any upgrade does it, to whichever namespace did not already exist at install time. `nullplatform-tools` and `nullplatform` survive in our deployment only by luck — Terraform creates them before the chart runs, so `lookup` finds them at install and they never enter the manifest at all.

## The fix

`helm.sh/resource-policy: keep` on all three. Helm then leaves the Namespace alone when it drops out of the manifest.

It is the minimal change: install semantics are untouched, and nothing gets adopted that the chart did not create. Verified `helm template` renders all three namespaces carrying the annotation, and `helm lint` passes.

## Alternative worth considering

Dropping the `lookup` guards and always rendering the namespaces would be more honest declaratively, but it breaks installs where a namespace already exists and is not owned by the release — which is exactly our layout, with Terraform creating `nullplatform-tools` first. Happy to go that way instead if you would rather fix the root pattern; this PR takes the safe route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)