### PR TITLE
fix(base): gateway PodDisruptionBudgets select zero pods

### DIFF
--- a/charts/base/templates/gateways.yaml
+++ b/charts/base/templates/gateways.yaml
@@ -157,9 +157,12 @@ metadata:
 spec:
   maxUnavailable: 50%
   selector:
-    # Match the generated Deployment by label
+    # Match the generated Deployment by label.
+    # Istio dropped `istio.io/gateway-name` in 1.24 for the Gateway API standard
+    # key below. With the old key this selector matches zero pods, so the PDB
+    # silently protects nothing.
     matchLabels:
-      istio.io/gateway-name: {{ .Values.gateway.internal.name }}
+      gateway.networking.k8s.io/gateway-name: {{ .Values.gateway.internal.name }}
 ---
 {{- end }}
 {{- if and .Values.gateways.enabled .Values.gateway.public.enabled }}
@@ -305,7 +308,7 @@ spec:
   selector:
     # Match the generated Deployment by label
     matchLabels:
-      istio.io/gateway-name: {{ .Values.gateway.public.name }}
+      gateway.networking.k8s.io/gateway-name: {{ .Values.gateway.public.name }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## The bug

Both gateway PDBs select on `istio.io/gateway-name`:

```yaml
  selector:
    matchLabels:
      istio.io/gateway-name: {{ .Values.gateway.public.name }}
```

Istio dropped that key in **1.24**, in favour of the Gateway API standard `gateway.networking.k8s.io/gateway-name` — the only gateway-name label its controller sets now.

A PDB whose selector matches nothing protects nothing, while still reading as configured in the chart and in `kubectl get pdb`.

## Evidence

Live cluster on Istio 1.27.1:

```console
$ kubectl get pdb -n gateways \
    -o custom-columns='NAME:.metadata.name,DESIRED:.status.desiredHealthy,CURRENT:.status.currentHealthy,ALLOWED:.status.disruptionsAllowed'
NAME              DESIRED   CURRENT   ALLOWED
gateway-private   0         0         0
gateway-public    0         0         0
```

`currentHealthy: 0` with four healthy gateway pods running is the tell — the PDB sees none of them. Their labels:

```console
$ kubectl get pods -n gateways -o json | jq -r '.items[0].metadata.labels'
{
  "gateway.istio.io/managed": "istio.io-gateway-controller",
  "gateway.networking.k8s.io/gateway-name": "gateway-public",
  "service.istio.io/canonical-name": "gateway-public-istio",
  ...
}
```

No `istio.io/gateway-name` anywhere.

## Impact

Both ingress paths can be drained to zero replicas during a node drain or a rolling update, with nothing holding a replica back — the `maxUnavailable: 50%` never applies.

Worth noting the failure mode is inverted from the usual PDB hazard: a PDB that matches nothing doesn't block evictions, it permits all of them. That is why this stayed invisible — nothing ever got stuck, traffic just dropped.

## The fix

Point both selectors at the label the pods actually carry. `helm lint` passes and `helm template` renders both PDBs with the corrected key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)