### PR TITLE
ci: auto-merge the release-please PR

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,12 @@
+name: auto-merge-release-pr
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+jobs:
+  automerge:
+    uses: nullplatform/actions-nullplatform/.github/workflows/auto-merge-release.yml@main
+    secrets:
+      app-id: ${{ secrets.APP_RELEASE_ID }}
+      app-private-key: ${{ secrets.APP_RELEASE_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Adds `auto-merge-release.yml`, mirroring the pattern already in use in [nullplatform/services-endpoint-exposer](https://github.com/nullplatform/services-endpoint-exposer/blob/main/.github/workflows/auto-merge-release.yml) — same reusable workflow, same secrets, no extra machinery.

Since this repo's release-please config has `"separate-pull-requests": false`, all 4 charts (`agent`, `base`, `cert-manager-config`, `istio-metrics`) share one combined release PR on `release-please--branches--main`. This just auto-merges that one PR — no per-chart logic needed.

## Known gap — needs a follow-up outside this PR

The repo's **"default branch"** ruleset requires 1 approving review and has **no `bypass_actors` configured** (confirmed via the API: `bypass_actors: null`). This workflow calls a reusable workflow that already uses `--admin` internally, but `--admin` only works if the App has real Administration permission or is a listed bypass actor — right now it's neither here.

**Needed**: someone with admin on `nullplatform/helm-charts` (or org admin) should add the `APP_RELEASE` GitHub App as a bypass actor on the "default branch" ruleset, the same way it's already configured on `nullplatform/tofu-modules`' "main" ruleset (`Integration`, `bypass_mode: always`). Until then, this workflow will run but the final merge step will fail with a policy error — visible and diagnosable, just not yet fully automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)