### PR TITLE
fix(base): omit the azure internal LB subnet annotation when unset

### DIFF
--- a/charts/base/templates/gateways.yaml
+++ b/charts/base/templates/gateways.yaml
@@ -55,7 +55,9 @@ metadata:
     {{- else if eq .Values.global.provider "aks" }}
     {{- if eq .Values.gateway.internal.loadBalancerType "internal" }}
     service.beta.kubernetes.io/azure-load-balancer-internal: 'true'
-    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: {{ .Values.gateway.internal.azure_load_balancer_subnet }}
+    {{- with .Values.gateway.internal.azure_load_balancer_subnet }}
+    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: {{ . | quote }}
+    {{- end }}
     {{- else }}
     service.beta.kubernetes.io/azure-load-balancer-internal: 'false'
     {{- end }}


### PR DESCRIPTION
First of three changes for a bug that left an AKS internal gateway without an address for days. This one is the prerequisite for the module-side fix.

## Problem

`charts/base/values.yaml` ships `gateway.internal.azure_load_balancer_subnet` empty, but the template emitted the annotation unconditionally:

```yaml
service.beta.kubernetes.io/azure-load-balancer-internal-subnet: {{ .Values.gateway.internal.azure_load_balancer_subnet }}
```

So a chart used without that value renders a **null annotation**:

```
service.beta.kubernetes.io/azure-load-balancer-internal:        'true'
service.beta.kubernetes.io/azure-load-balancer-internal-subnet:          ← null
```

The `azure-load-balancer-security-groups` annotation a few lines below is already guarded with `{{- if }}`; this one was the exception.

## Why nobody hit it yet

The `nullplatform/base` tofu module always passes a value, because its `internal_azure_load_balancer_subnet` defaults to `"load_balancer"`. That default is wrong in a different way — it is the **key** of the `subnets_definition` map, not a subnet name — so on a real install it annotates a non-existent subnet and Azure answers:

```
403 AuthorizationFailed ... over scope '.../subnets/load_balancer' or the scope is invalid
```

which reads like missing RBAC and is not. Fixing that default upstream means defaulting to **empty** (matching the module's own `gateway_public_azure_load_balancer_subnet`, documented as "empty by default, in which case Azure picks the subnet automatically"). That change needs this guard first, or the null annotation becomes the common path instead of the rare one.

## Verification

```
# unset (values.yaml default)
service.beta.kubernetes.io/azure-load-balancer-internal: 'true'
service.beta.kubernetes.io/port_443_health-probe_protocol: "tcp"
   → subnet annotation omitted, Azure auto-selects

# --set gateway.internal.azure_load_balancer_subnet=subnet-4
service.beta.kubernetes.io/azure-load-balancer-internal: 'true'
service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "subnet-4"
```

`with` instead of `if` so the value is only referenced when present, and quoted for subnet names that could otherwise be parsed as non-strings.

No version bump here — release-please owns `Chart.yaml`.

## The other two

- `tofu-modules` / `nullplatform/base`: default `"load_balancer"` → `""`.
- `tofu-modules` / `infrastructure/azure/aks`: the module grants Network Contributor only on the subnet it is handed (the node subnet), so the internal-LB subnet has no permissions and a correct name still 403s.

`charts/routing/templates/gateways.yaml` carries the same unguarded line on the `feat/nullplatform-routing-chart` branch and will need the same change before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
