### PR TITLE
fix(ci): serialize release-please runs on consecutive main pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,19 @@ on:
     branches:
       - main
 
+# Serializes consecutive pushes to main so release-please never has two runs
+# racing over the same release PR's state. Without this, two pushes landing
+# within the ~45s auto-merge window can overlap: one run merges/creates a
+# release PR while another, already mid-flight, tries to update the PR that
+# just got merged and fails with "the pull request cannot be reopened"
+# (observed live on 2026-08-07, PR #169/#170). cancel-in-progress: false
+# queues the newer push instead of cancelling the in-flight one, since
+# cancelling could interrupt a release-please run partway through mutating
+# GitHub state (tags, releases, PR labels).
+concurrency:
+  group: main-branch-push
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Problem

Two pushes to `main` landing close together let two `release-please` runs overlap: one merges/creates the release PR while another run, already mid-flight with stale state, tries to update the PR that just got merged and fails:

```
⚠ updated code for 170, but update requested for 169
##[error] ... 422 the pull request cannot be reopened
```

Observed live on 2026-08-07 (PR #169/#170, ~90s window). Same signature as [nullplatform/tofu-modules#485](https://github.com/nullplatform/tofu-modules/pull/485)'s underlying issue.

## Fix

Add the same top-level `concurrency` group that `nullplatform/tofu-modules`' `release.yml` already uses, so overlapping pushes to `main` queue instead of racing. `cancel-in-progress: false` because cancelling a run mid-flight could interrupt `release-please` while it's mutating GitHub state (tags, releases, labels).

Note: this doesn't fully eliminate the class of race seen in tofu-modules#485 (that one happened even *with* this same concurrency block, from two runs executing back-to-back rather than in parallel) — but it does close the specific parallel-execution case seen here, which is a wider and easier-to-hit window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)