### PR TITLE
fix(ci): use rebase merge method for auto-merge-release-pr

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,3 +10,9 @@ jobs:
     secrets:
       app-id: ${{ secrets.APP_RELEASE_ID }}
       app-private-key: ${{ secrets.APP_RELEASE_PRIVATE_KEY }}
+    # This repo only allows rebase merges (Settings > General > Pull Requests
+    # has "Allow merge commits" and "Allow squash merging" both off) --
+    # the reusable workflow's default merge_method ("merge") fails with
+    # "GraphQL: Merge commits are not allowed on this repository."
+    with:
+      merge_method: rebase


### PR DESCRIPTION
PR #174's auto-merge run failed at the final merge step:

\`\`\`
GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)
\`\`\`

This repo has both "Allow merge commits" and "Allow squash merging" disabled (only rebase is on), but the reusable workflow defaults \`merge_method\` to \`merge\`. Setting it explicitly to \`rebase\` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)