### PR TITLE
fix(istio-metrics): document the exporter port dependency

### DIFF
--- a/charts/istio-metrics/values.yaml
+++ b/charts/istio-metrics/values.yaml
@@ -66,6 +66,7 @@ gateway:
 exporter:
   enabled: true
   image: "python:3.11-slim"
+  # Port the exporter listens on; must match prometheus.server.extraScrapeConfigs' target port above
   port: 9101
   resources:
     requests:


### PR DESCRIPTION
Small real fix used as an end-to-end test of release-please -> auto-merge -> package-and-publish for the istio-metrics chart specifically. Clarifies that `exporter.port` must match the scrape target port in `prometheus.server.extraScrapeConfigs`.