### PR TITLE
fix(ci): trigger release PR auto-merge via workflow_run instead of pull_request

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,11 +1,67 @@
 name: auto-merge-release-pr
 
+# workflow_run instead of pull_request: the release PR is opened by
+# github-actions[bot] via the default token, whose author_association on
+# this repo is CONTRIBUTOR rather than MEMBER/COLLABORATOR -- enough for
+# GitHub's "require approval for outside collaborators" gate to sometimes
+# treat its pull_request-triggered runs as needing manual approval, even
+# though the branch isn't a fork (observed intermittently on PR #174, #177 --
+# action_required with zero jobs run, requiring a manual label toggle to
+# retry). workflow_run runs use the workflow file from the default branch
+# with full permissions and aren't subject to that gate. Same fix already
+# applied to nullplatform/tofu-modules' auto-merge-release.yml.
 on:
-  pull_request:
-    types: [opened, synchronize, labeled]
+  workflow_run:
+    workflows: ["Release Charts"]
+    types: [completed]
 
 jobs:
+  find-pr:
+    name: Resolve open release PR
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    outputs:
+      pr_number: ${{ steps.find.outputs.pr_number }}
+    steps:
+      # workflow_run doesn't carry pull_request context, so we resolve the
+      # release PR ourselves and validate its author/label -- this is what
+      # the reusable workflow's pr_number input expects the caller to do for
+      # non-pull_request triggers. Uses the REST API (not `gh pr list
+      # --json author`, which is GraphQL-backed and reports this bot as
+      # "app/github-actions" instead of "github-actions[bot]").
+      - name: Find open release-please PR
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls" \
+            -X GET \
+            -f state=open \
+            -f "head=${REPO_OWNER}:release-please--branches--main" \
+            --jq '.[0] // empty')
+
+          if [ -z "$PR_JSON" ]; then
+            echo "No open release-please PR found."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+          HAS_LABEL=$(echo "$PR_JSON" | jq '[.labels[].name] | contains(["autorelease: pending"])')
+
+          if [ "$AUTHOR" != "github-actions[bot]" ] || [ "$HAS_LABEL" != "true" ]; then
+            echo "Open PR doesn't match expected author/label. Skipping."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "pr_number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+
   automerge:
+    name: Auto-merge release PR
+    needs: find-pr
+    if: needs.find-pr.outputs.pr_number != ''
     uses: nullplatform/actions-nullplatform/.github/workflows/auto-merge-release.yml@main
     secrets:
       app-id: ${{ secrets.APP_RELEASE_ID }}
@@ -16,3 +72,4 @@ jobs:
     # "GraphQL: Merge commits are not allowed on this repository."
     with:
       merge_method: rebase
+      pr_number: ${{ fromJson(needs.find-pr.outputs.pr_number) }}


### PR DESCRIPTION
## Problem

`auto-merge-release-pr` intermittently gets blocked with `action_required` and zero jobs run, on the release-please PR specifically -- observed twice each on PR #174 and #177, needing a manual label toggle (remove/re-add \`autorelease: pending\`) to force a retry that succeeds.

Root cause: the release PR is opened by \`github-actions[bot]\` via the default token, whose \`author_association\` on this repo is \`CONTRIBUTOR\` rather than \`MEMBER\`/\`COLLABORATOR\` -- enough for GitHub's "require approval for outside collaborators" gate to sometimes treat its \`pull_request\`-triggered runs as needing manual approval, even though the branch isn't a fork.

## Fix

Same fix already applied and verified end-to-end on [nullplatform/tofu-modules](https://github.com/nullplatform/tofu-modules/pull/479): switch the trigger from \`pull_request\` to \`workflow_run\` (on \`"Release Charts"\` completing), which isn't subject to that gate. Since \`workflow_run\` doesn't carry PR context, a \`find-pr\` job resolves the open release PR itself (via the REST API, to correctly match \`github-actions[bot]\`'s login format) and validates its author/label before calling the reusable workflow with \`pr_number\`.

## Test plan

- [ ] Merge this PR.
- [ ] Wait for the next chart fix/feat PR to merge, and confirm \`auto-merge-release-pr\` fires via \`workflow_run\` and merges the release PR without any \`action_required\`/manual nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)